### PR TITLE
Feature/support nsf2 #7

### DIFF
--- a/src/nsc/MetaItem.cpp
+++ b/src/nsc/MetaItem.cpp
@@ -1,0 +1,246 @@
+/*******************************************************************************
+
+			NES Sound Driver & Library	(NSD.lib)	MML Compiler
+
+	Copyright (c) 2012 A.Watanabe (S.W.), All rights reserved.
+	 For conditions of distribution and use, see copyright notice in "nsc.cpp".
+
+*******************************************************************************/
+
+#include "StdAfx.h"
+#include "MetaItem.h"
+
+/****************************************************************/
+/*					グローバル変数（クラスだけど・・・）		*/
+/****************************************************************/
+extern	OPSW*			cOptionSW;	//オプション情報へのポインタ変数
+
+//==============================================================
+//		コンストラクタ
+//--------------------------------------------------------------
+//	●引数
+//		const	char	_strName[]	identifier
+//	●返値
+//				無し
+//==============================================================
+MetaItem::MetaItem(const char _strName[]):
+	m_identifier(_strName),
+	m_size(0),
+	m_offset(0)
+{
+	//Debug message　（うざい程出力するので注意。）
+	if(cOptionSW->cDebug & DEBUG_Create){
+		_COUT << _T("Create Meta Object : ") << m_identifier << endl;
+	}
+}
+
+//==============================================================
+//		デストラクタ
+//--------------------------------------------------------------
+//	●引数
+//				無し
+//	●返値
+//				無し
+//==============================================================
+MetaItem::~MetaItem(void)
+{
+	clear();
+
+	//Debug message　（うざい程出力するので注意。）
+	if(cOptionSW->cDebug & DEBUG_Delete){
+		_COUT << _T("Delete Meta Object : ") << m_identifier << endl;
+	}
+}
+
+//==============================================================
+//		クリア
+//--------------------------------------------------------------
+//	●引数
+//				無し
+//	●返値
+//				無し
+//==============================================================
+void	MetaItem::clear(void)
+{
+	//----------------------
+	//Local変数
+	list<	MetaItem*>::iterator	itItem;
+
+	//----------------------
+	//clear
+	m_data.clear();
+
+	//----------------------
+	//Delete Class
+	if(!ptcItem.empty()){
+		itItem = ptcItem.begin();
+		while(itItem != ptcItem.end()){
+			delete *itItem;
+			itItem++;
+		}
+		ptcItem.clear();
+	}
+
+	m_size = 0;
+}
+
+//==============================================================
+//		コードサイズの取得
+//--------------------------------------------------------------
+//	●引数
+//				無し
+//	●返値
+//		size_t
+//==============================================================
+size_t		MetaItem::getSize()
+{
+	return(m_size);
+}
+
+//==============================================================
+//		コードのオフセットアドレスの取得
+//--------------------------------------------------------------
+//	●引数
+//				無し
+//	●返値
+//		size_t
+//==============================================================
+size_t	MetaItem::getOffset()
+{
+	return(m_offset);
+}
+
+//==============================================================
+//		オフセットアドレスの設定
+//--------------------------------------------------------------
+//	●引数
+//		size_t	_offset
+//	●返値
+//				無し
+//==============================================================
+size_t	MetaItem::SetOffset(size_t _offset)
+{
+	//----------------------
+	//Local変数
+	list<	MetaItem*>::iterator	itItem;
+	size_t	i = 0;
+
+	//Debug message　（うざい程出力するので注意。）
+	if(cOptionSW->cDebug & DEBUG_SetAddress){
+		_COUT << _T("Object Address [0x") << hex << setw(4) << setfill(_T('0')) << _offset << _T("]: ");
+		while(i < m_data.size()){
+			_COUT	<<	hex	<<	setw(2)	<<	setfill(_T('0'))	<<	(unsigned int)(m_data[i] & 0xFF)	<<	_T(" ");
+			i++;
+		}
+		_COUT  << dec	<< _T(": ") << m_identifier << endl;
+	}
+
+	m_offset = _offset;
+	_offset	+= m_data.size();
+
+	if(!ptcItem.empty()){
+		itItem = ptcItem.begin();
+		while(itItem != ptcItem.end()){
+			_offset = (*itItem)->SetOffset(_offset);
+			itItem++;
+		}
+	}
+
+	//このオブジェクトのサイズ（最適化後）
+	m_size = _offset - m_offset;
+
+	//Size と ID の分を加算
+	_offset += 8;
+
+	return(_offset);
+}
+
+//==============================================================
+//		コードの取得
+//--------------------------------------------------------------
+//	●引数
+//					size_t	添え字
+//	●返値
+//		unsigned	char	内容
+//==============================================================
+unsigned	char	MetaItem::getData(size_t n)
+{
+	unsigned	char	iData;
+	
+	if((n<0) || (n>=m_size)){
+		iData = 0xFF;
+	} else {
+		iData = m_data[n];
+	}
+
+	return(iData);
+}
+
+//==============================================================
+//		コードの取得
+//--------------------------------------------------------------
+//	●引数
+//		string*		_str
+//	●返値
+//				無し
+//==============================================================
+void	MetaItem::getData(string* _str)
+{
+	//----------------------
+	//Local変数
+	list<	MetaItem*>::iterator	itItem;
+
+	_str->append(m_data);
+
+	if(!ptcItem.empty()){
+		itItem = ptcItem.begin();
+		while(itItem != ptcItem.end()){
+			(*itItem)->getMetaData(_str);
+			itItem++;
+		}
+	}
+}
+
+//==============================================================
+//		コードの取得
+//--------------------------------------------------------------
+//	●引数
+//		string*		_str
+//	●返値
+//				無し
+//==============================================================
+void	MetaItem::getMetaData(string* _str)
+{
+	string	strSize;
+
+	strSize.resize(4);
+
+	//SIZE
+	strSize[0] = (unsigned char)(m_size      ) & 0xFF;
+	strSize[1] = (unsigned char)(m_size >>  8) & 0xFF;
+	strSize[2] = (unsigned char)(m_size >> 16) & 0xFF;
+	strSize[3] = (unsigned char)(m_size >> 24) & 0xFF;
+	_str->append(strSize);
+
+	//ID
+	_str->append(m_identifier, 4);
+
+	//Data
+	getMetaData(_str);
+}
+
+//==============================================================
+//		コードの設定
+//--------------------------------------------------------------
+//	●引数
+//		string*		_str
+//	●返値
+//				無し
+//==============================================================
+void	MetaItem::setMetaData(string* _str)
+{
+	m_data.clear();
+	m_data.assign(*_str);
+	m_size = m_data.size();
+}
+

--- a/src/nsc/MetaItem.h
+++ b/src/nsc/MetaItem.h
@@ -1,0 +1,48 @@
+/*******************************************************************************
+
+			NES Sound Driver & Library	(NSD.lib)	MML Compiler
+
+	Copyright (c) 2012 A.Watanabe (S.W.), All rights reserved.
+	 For conditions of distribution and use, see copyright notice in "nsc.cpp".
+
+*******************************************************************************/
+
+#pragma once
+
+/****************************************************************/
+/*			プロトタイプ										*/
+/****************************************************************/
+class	MusicFile;
+
+
+/****************************************************************/
+/*																*/
+/*			クラス定義											*/
+/*																*/
+/****************************************************************/
+class MetaItem
+{
+//メンバー変数
+protected:
+	const		char*		m_identifier;		//オブジェクトの名称
+				size_t		m_size;				//Chunkのサイズ
+				string		m_data;				//実体
+	list<MetaItem*>			ptcItem;			//構造化
+				size_t		m_offset;			//SNDファイルポインタ
+
+//メンバー関数
+public:
+	MetaItem(const char m_identifier[]="");
+	~MetaItem(void);
+
+				void	clear(void);
+				size_t	getSize();
+				size_t	getOffset();
+				size_t	SetOffset(size_t _offset);
+
+	unsigned	char	getData(size_t n);
+	virtual		void	getData(string* _str);
+	virtual		void	getMetaData(string* _str);
+	virtual		void	setMetaData(string* _str);
+
+};

--- a/src/nsc/MusicFile.h
+++ b/src/nsc/MusicFile.h
@@ -11,33 +11,6 @@
 
 /****************************************************************/
 /*																*/
-/*			定数定義											*/
-/*																*/
-/****************************************************************/
-struct	NSF_Header{
-				char	Name[5];			//00	"NESM",0x1A
-	unsigned	char	Version;			//05
-	unsigned	char	MusicNumber;		//06
-	unsigned	char	StartMusicNumber;	//07
-	unsigned	short	LoadAddress;		//08
-	unsigned	short	InitAddress;		//0A
-	unsigned	short	MainAddress;		//0C
-				char	Title[32];			//0E
-				char	Composer[32];		//2E
-				char	Copyright[32];		//4E
-	unsigned	short	Frequency_NTSC;		//6E
-	unsigned	char	Bank[8];			//70
-	unsigned	short	Frequency_PAL;		//78
-	unsigned	char	Video;				//7A
-	unsigned	char	External;			//7B
-	unsigned	char	Null1;				//7C
-	unsigned	char	Null2;				//7D
-	unsigned	char	Null3;				//7E
-	unsigned	char	Null4;				//7F
-};
-
-/****************************************************************/
-/*																*/
 /*			クラス定義											*/
 /*																*/
 /****************************************************************/

--- a/src/nsc/MusicHeader.h
+++ b/src/nsc/MusicHeader.h
@@ -11,6 +11,31 @@
 
 /****************************************************************/
 /*																*/
+/*			構造体定義											*/
+/*																*/
+/****************************************************************/
+struct	NSF_Header{
+				char	Name[5];			//00	"NESM",0x1A
+	unsigned	char	Version;			//05
+	unsigned	char	MusicNumber;		//06
+	unsigned	char	StartMusicNumber;	//07
+	unsigned	short	LoadAddress;		//08
+	unsigned	short	InitAddress;		//0A
+	unsigned	short	MainAddress;		//0C
+				char	Title[32];			//0E
+				char	Composer[32];		//2E
+				char	Copyright[32];		//4E
+	unsigned	short	Frequency_NTSC;		//6E
+	unsigned	char	Bank[8];			//70
+	unsigned	short	Frequency_PAL;		//78
+	unsigned	char	Video;				//7A
+	unsigned	char	External;			//7B
+	unsigned	char	Flags;				//7C
+	unsigned	char	szMetaData[3];		//7D-7F
+};
+
+/****************************************************************/
+/*																*/
 /*			クラス定義											*/
 /*																*/
 /****************************************************************/

--- a/src/nsc/makefile
+++ b/src/nsc/makefile
@@ -21,6 +21,7 @@ OBJS	=	BGM.o			\
 			FDSM.o			\
 			FileInput.o		\
 			FileOutput.o	\
+			MetaItem.o		\
 			mml_Address.o	\
 			mml_CallSub.o	\
 			mml_general.o	\

--- a/src/nsc/nsc.vcproj
+++ b/src/nsc/nsc.vcproj
@@ -243,6 +243,13 @@
 						RelativePath=".\MusicEvent.cpp">
 					</File>
 				</Filter>
+				<Filter
+					Name="Meta"
+					Filter="">
+					<File
+						RelativePath=".\MetaItem.cpp">
+					</File>
+				</Filter>
 			</Filter>
 			<Filter
 				Name="MML"
@@ -289,6 +296,9 @@
 			</File>
 			<File
 				RelativePath=".\FileOutput.h">
+			</File>
+			<File
+				RelativePath=".\MetaItem.h">
 			</File>
 			<File
 				RelativePath=".\mml_Address.h">

--- a/src/nsc/stdafx.h
+++ b/src/nsc/stdafx.h
@@ -99,6 +99,9 @@ typedef struct {
 #include "mml_Address.h"
 #include "mml_CallSub.h"
 
+#include "MetaItem.h"
+
+
 #include "MusicHeader.h"		//ƒwƒbƒ_[
 
 #include "nsd_work.h"

--- a/src/nsc64/nsc64.vcxproj
+++ b/src/nsc64/nsc64.vcxproj
@@ -169,6 +169,7 @@
     <ClInclude Include="..\nsc\FDSM.h" />
     <ClInclude Include="..\nsc\FileInput.h" />
     <ClInclude Include="..\nsc\FileOutput.h" />
+    <ClInclude Include="..\nsc\MetaItem.h" />
     <ClInclude Include="..\nsc\MMLfile.h" />
     <ClInclude Include="..\nsc\mml_Address.h" />
     <ClInclude Include="..\nsc\mml_CallSub.h" />
@@ -206,6 +207,7 @@
     <ClCompile Include="..\nsc\FDSM.cpp" />
     <ClCompile Include="..\nsc\FileInput.cpp" />
     <ClCompile Include="..\nsc\FileOutput.cpp" />
+    <ClCompile Include="..\nsc\MetaItem.cpp" />
     <ClCompile Include="..\nsc\MMLfile.cpp" />
     <ClCompile Include="..\nsc\mml_Address.cpp" />
     <ClCompile Include="..\nsc\mml_CallSub.cpp" />

--- a/src/nsc64/nsc64.vcxproj.filters
+++ b/src/nsc64/nsc64.vcxproj.filters
@@ -28,6 +28,9 @@
     <Filter Include="ソース ファイル\Music\Event">
       <UniqueIdentifier>{1da4e2d4-db17-4dca-86cd-b56a02e71734}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ソース ファイル\Music\Meta">
+      <UniqueIdentifier>{14ef4836-2849-430a-baad-8d7141ebbaf6}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="nsc64.rc">
@@ -139,6 +142,9 @@
     <ClInclude Include="..\nsc\MusicNote.h">
       <Filter>ヘッダー ファイル</Filter>
     </ClInclude>
+    <ClInclude Include="..\nsc\MetaItem.h">
+      <Filter>ヘッダー ファイル</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\nsc\nsc.cpp">
@@ -236,6 +242,9 @@
     </ClCompile>
     <ClCompile Include="..\nsc\MusicNote.cpp">
       <Filter>ソース ファイル\Music</Filter>
+    </ClCompile>
+    <ClCompile Include="..\nsc\MetaItem.cpp">
+      <Filter>ソース ファイル\Music\Meta</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Meta Data の各アイテムの基底クラスとして、"MetaItem.cpp" and "MetaItem.h"を作成
- NSF_Headerの構造体定義を、NSF2に対応
- MusicFileクラス内のsaveNSF()関数内にて、 *.bin ファイルを読み込む時に、以下を分けて読み込むようにした。
  （Meta Dataは、ヘッダーと、ROMイメージの間に入る仕様であるため）
  - NSFヘッダー
  - ROMコード（音源ドライバ部）


