### PR TITLE
Fixed: nsd.lib cannot work in TNS-HFC4

### DIFF
--- a/src/rom/crt0.s
+++ b/src/rom/crt0.s
@@ -107,7 +107,7 @@ _play:	.byte	0
 DRV_Name:	.byte	$4E, $53, $44, $4C, $20, $20
 DRV_Version:	.byte	1
 		.byte	29
-		.byte	0,0,0,0,0,0,0,0
+;		.byte	0,0,0,0,0,0,0,0		;TNS-HFC—p GAP
 
 .ifdef	DPCMBank
 .segment	"STARTUP"

--- a/src/rom/default.cfg
+++ b/src/rom/default.cfg
@@ -2,8 +2,7 @@
 MEMORY {
 
 	HEADER:	start = $0,		size = $80,		type = ro,	file = %O,	fill = yes;					#NSF Header
-	DINFO:	start = $8000,	size = $0010,	type = ro,	file = %O,	fill = no,	define = yes;	#Music page		0x8000 - 0xFFFF
-	ROM0:	start = $8010,	size = $7FF0,	type = ro,	file = %O,	fill = no,	define = yes;	#Music page		0x8000 - 0xFFFF
+	ROM0:	start = $8000,	size = $8000,	type = ro,	file = %O,	fill = no,	define = yes;	#Music page		0x8000 - 0xFFFF
 	ZP:		start = $02,	size = $FE,		type = rw,							define = yes;	#Zeropage		0x0000 - 0x00FF
 	SRAM:	start = $0200,	size = $0600,	type = rw,							define = yes;	#SRAM			0x0200 - 0x07FF
 	RAM:	start = $6000,	size = $2000,	type = rw,							define = yes;	#RAM			0x6000 - 0x7FFF
@@ -11,7 +10,7 @@ MEMORY {
 
 SEGMENTS {
 	HEADER:		load = HEADER,          type = ro;
-	DRVINFO:	load = DINFO,           type = ro;
+	DRVINFO:	load = ROM0,            type = ro;
 	STARTUP:	load = ROM0,            type = ro,  define = yes;
 	LOWCODE:	load = ROM0,            type = ro,                optional = yes;
 	INIT:		load = ROM0,            type = ro,  define = yes, optional = yes;


### PR DESCRIPTION
Bug Fixed: `nsd.lib` cannot work in TNS-HFC4.